### PR TITLE
Fix GumpTextEdit to use correct ID

### DIFF
--- a/ScriptSDK/Gumps/Controls/GumpTextEdit.cs
+++ b/ScriptSDK/Gumps/Controls/GumpTextEdit.cs
@@ -36,6 +36,7 @@ namespace ScriptSDK.Gumps
             Limit = -1;
             Page = c.Page;
             ElementID = c.ElemNum;
+            ReturnValue = c.ReturnValue;
         }
 
         internal GumpTextEdit(Gump owner, TextEntryLimited c)
@@ -52,6 +53,7 @@ namespace ScriptSDK.Gumps
             Limit = c.Limit;
             Page = c.Page;
             ElementID = c.ElemNum;
+            ReturnValue = c.ReturnValue;
         }
 
         private Gump Owner { get; set; }
@@ -85,6 +87,11 @@ namespace ScriptSDK.Gumps
         /// </summary>
         public int TextID { get; private set; }
 
+        /// <summary>
+        /// Stores ReturnValue of control, which is only exposed for debug research. The control will handle actions standalone.
+        /// </summary>
+        public int ReturnValue { get; private set; }
+
         private string _text { get; set; }
 
         /// <summary>
@@ -100,7 +107,7 @@ namespace ScriptSDK.Gumps
                 var index = Gump.GetGumpIndex(Owner.GumpType);
                 if (Events.InvokeOnGumpReply(Owner,
                     new GumpReplyEventArgs(this,
-                        (index >= 0) && Stealth.Client.NumGumpTextEntry((ushort)index, TextID, value))))
+                        (index >= 0) && Stealth.Client.NumGumpTextEntry((ushort) index, ReturnValue, value))))
                     _text = value;
             }
         }


### PR DESCRIPTION
GumpTextEdit has to call NumGumpTextEntry with ReturnValue instead of TextID.
TextID only refers to which transmitted string should be displayed.

Source:
http://stealth.od.ua/Doc:Manual/Reference/Gump#NumGumpTextEntry

fixes #10