### PR TITLE
Updated Packet Parse Error

### DIFF
--- a/ScriptSDK/Gumps/GumpEnums.cs
+++ b/ScriptSDK/Gumps/GumpEnums.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace ScriptSDK.Gumps
+{
+    /// <summary>
+    /// OSI based GumpIDs to let you know what gump you are specifically wanting.
+    /// </summary>
+    /// <example> Gump.GetGump((uint)OSIGumpIDs.Runebook)</example>
+    public enum OSIGumpIDs : uint
+    {
+        /// <summary>
+        /// Returns Runebook GumpID
+        /// </summary>
+        Runebook = 0x0059,
+        /// <summary>
+        /// Returns Moongate GumpID
+        /// </summary>
+        Moongate = 0x0258,
+    }
+}

--- a/ScriptSDK/Items/Runebook.cs
+++ b/ScriptSDK/Items/Runebook.cs
@@ -1,0 +1,361 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ScriptSDK.Data;
+using ScriptSDK.Engines;
+using ScriptSDK.Gumps;
+using ScriptSDK.Utils;
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace ScriptSDK.Items
+{
+
+    public struct RuneBookConfig
+
+    {
+        public int ScrollOffset { get; set; }
+        public int DropOffset { get; set; }
+        public int DefaultOffset { get; set; }
+        public int RecallOffset { get; set; }
+        public int GateOffset { get; set; }
+        public int SacredOffset { get; set; }
+        public int Jumper { get; set; }
+    }
+
+    public class RunebookEntry
+    {
+        private readonly Runebook _owner;
+        private readonly GumpButton _recall;
+        private readonly GumpButton _gate;
+        private readonly GumpButton _sacred;
+        private readonly GumpButton _scroll;
+        private readonly GumpButton _default;
+        private readonly GumpButton _drop;
+        public string Name { get; private set; }
+        public string Location { get; private set; }
+        public Map Map { get; private set; }
+        public Point3D Position { get; private set; }
+
+        internal RunebookEntry(Runebook owner, GumpButton recall, GumpButton gate, GumpButton sacred, GumpButton scroll, GumpButton def, GumpButton drop, string location, string name, int color)
+        {
+            _owner = owner;
+            _recall = recall;
+            _gate = gate;
+            _sacred = sacred;
+            _scroll = scroll;
+            _default = def;
+            _drop = drop;
+            Name = name;
+            Location = location;
+            Map = Map.Internal;
+            switch (color)
+            {
+                case 1102:
+                    Map = Map.Malas;
+                    break;
+                case 81:
+                    Map = Map.Felucca;
+                    break;
+                case 10:
+                    Map = Map.Trammel;
+                    break;
+                case 1154:
+                    Map = Map.Tokuno;
+                    break;
+                case 0:
+                    Map = Map.TerMur;
+                    break;
+            }
+            Position = Geometry.CoordsToPoint(Location, Map);
+        }
+        internal RunebookEntry(Runebook owner, GumpButton recall, GumpButton gate, GumpButton sacred, GumpButton scroll, GumpButton def, GumpButton drop, string name)
+        {
+            _owner = owner;
+            _recall = recall;
+            _gate = gate;
+            _sacred = sacred;
+            _scroll = scroll;
+            _default = def;
+            _drop = drop;
+            Name = name;
+        }
+
+        public bool SetDefault()
+        {
+            return _owner.Open() && _default.Click();
+        }
+
+        public bool Recall()
+        {
+            return _owner.Open() && _recall.Click();
+        }
+
+        public bool Sacred()
+        {
+            return _owner.Open() && _sacred.Click();
+        }
+
+        public bool Gate()
+        {
+            return _owner.Open() && _gate.Click();
+        }
+
+        public bool UseScroll()
+        {
+            return _owner.Open() && _scroll.Click();
+        }
+        public bool DropRune()
+        {
+            return _owner.Open() && _drop.Click();
+        }
+
+    }
+
+    [QuerySearch(0x22C5)]
+    public class Runebook : Item
+    {
+        public override int DefaultLabelNumber
+        {
+            get { return 1041267; }
+        }
+        public int DefaultRune { get; private set; }
+        public List<RunebookEntry> Entries { get; private set; }
+        public Range Uses { get; private set; }
+        public string Description
+        {
+            get
+            {
+                return !ClilocHelper.Contains(Properties, 1042971) ? string.Empty : ClilocHelper.GetParams(Properties, 1042971)[0];
+            }
+        }
+        public string Crafter
+        {
+            get
+            {
+                return !ClilocHelper.Contains(Properties, 1050043) ? string.Empty : ClilocHelper.GetParams(Properties, 1050043)[0];
+            }
+        }
+        public bool Exceptional
+        {
+            get
+            {
+                return (ClilocHelper.Contains(Properties, 1060636));
+            }
+        }
+        public RuneBookConfig Configuration { get; set; }
+        private uint GumpType { get; set; }
+        private ushort GumpDelay { get; set; }
+        private string Shard { get; set;} 
+
+        private GumpButton RenameButton { get; set; }
+                
+        public Runebook(Serial serial, RuneBookConfig config)
+            : base(serial)
+        {
+            GumpType = 0x0059;
+            GumpDelay = 1000;
+            Entries = new List<RunebookEntry>();
+            Uses = new Range(0, 0);
+            DefaultRune = -1;
+            Configuration = config;
+            Shard = "OSI";
+        }
+        public Runebook(uint value, RuneBookConfig config)
+            : this(new Serial(value), config)
+        { }
+
+        public bool Parse()
+        {
+            if (!Close() || !Open())
+                return false;
+
+            var g = Gump.GetGump(GumpType);
+
+            UpdateLocalizedProperties();
+
+            int scrolloffset = Configuration.ScrollOffset;
+            int dropoffset = Configuration.DropOffset;
+            int defaultoffset = Configuration.DefaultOffset;
+            int recalloffset = Configuration.RecallOffset;
+            int gateoffset = Configuration.GateOffset;
+            int sacredoffset = Configuration.SacredOffset;
+            int jumper = Configuration.Jumper;
+
+            dynamic min = string.Empty;
+            dynamic max = string.Empty;
+
+            if (g.HTMLTexts.Count > 0)
+                min = g.HTMLTexts[0].Text;
+            if (g.HTMLTexts.Count > 1)
+                max = g.HTMLTexts[1].Text;
+
+            int imin;
+            if (!int.TryParse(min, out imin))
+                imin = -1;
+            int imax;
+            if (!int.TryParse(max, out imax))
+                imax = -1;
+
+            Uses = new Range(imin, imax);
+            if (Shard == "OSI")
+            {
+                int eamt = 0;
+                for (var i = 0; i < 15; i++)
+                {
+                    if (g.Buttons.Any(
+                            e =>
+                                e.PacketValue.Equals(defaultoffset + (i)) && e.Graphic.Released.Equals(2361) &&
+                                e.Graphic.Pressed.Equals(2361)))
+                        eamt++;
+                }
+
+                var namepos = (eamt);
+
+                var defaultbtn = g.Buttons.First(e => e.Graphic.Released.Equals(2361) && e.Graphic.Pressed.Equals(2361));
+                if (defaultbtn != null)
+                {
+                    var value = ((defaultbtn.PacketValue - defaultoffset) / jumper) + 1;
+                    DefaultRune = value;
+                }
+
+                var rButton = g.Buttons.First(e => e.Graphic.Released.Equals(2472) || e.Graphic.Pressed.Equals(2473));
+                RenameButton = rButton;
+
+                for (var i = 0; i < 15; i++)
+                {
+                    var valid =
+                        g.Buttons.Any(
+                            e =>
+                                e.PacketValue.Equals(defaultoffset + (i)) && e.Graphic.Released.Equals(2361) &&
+                                e.Graphic.Pressed.Equals(2361));
+
+                    if (!valid) continue;
+                    var recallButton = g.Buttons.First(e => e.PacketValue.Equals(recalloffset + (i)));
+                    var gateButton = g.Buttons.First(e => e.PacketValue.Equals(gateoffset + (i)));
+                    var sacredButton = g.Buttons.First(e => e.PacketValue.Equals(sacredoffset + (i)));
+                    var dropButton = g.Buttons.First(e => e.PacketValue.Equals(dropoffset + (i)));
+                    var scrollButton = g.Buttons.First(e => e.PacketValue.Equals(scrolloffset + (i)));
+                    var defaultButton = g.Buttons.First(e => e.PacketValue.Equals(defaultoffset + (i)));
+                    var name = g.Labels[namepos].Text;
+
+                    Entries.Add(new RunebookEntry(this, recallButton, gateButton, sacredButton, scrollButton,
+                            defaultButton, dropButton, name));
+                }
+            }
+            else
+            {
+                int eamt = 0;
+                for (var i = 0; i < 15; i++)
+                {
+                    if (g.Buttons.Any(e => e.PacketValue.Equals(recalloffset + (i*jumper)) &&
+                                           e.Graphic.Released.Equals(2103) &&
+                                           e.Graphic.Pressed.Equals(2104)))
+                        eamt++;
+                }
+
+                var namepos = (eamt*2);
+
+                var defaultbtn = g.Buttons.First(e => e.Graphic.Released.Equals(2361) && e.Graphic.Pressed.Equals(2361));
+                if (defaultbtn != null)
+                {
+                    var value = ((defaultbtn.PacketValue - defaultoffset) / jumper) + 1;
+                    DefaultRune = value;
+                }
+
+                var rButton = g.Buttons.First(e => e.Graphic.Released.Equals(2472) || e.Graphic.Pressed.Equals(2473));
+                RenameButton = rButton;
+
+                for (var i = 0; i < 15; i++)
+                {
+                    var valid =
+                        g.Buttons.Any(
+                            e =>
+                                e.PacketValue.Equals(recalloffset + (i*jumper)) && e.Graphic.Released.Equals(2103) &&
+                                e.Graphic.Pressed.Equals(2104));
+
+                    if (!valid) continue;
+                    var recallButton = g.Buttons.First(e => e.PacketValue.Equals(recalloffset + (i*jumper)));
+                    var gateButton = g.Buttons.First(e => e.PacketValue.Equals(gateoffset + (i*jumper)));
+                    var sacredButton = g.Buttons.First(e => e.PacketValue.Equals(sacredoffset + (i*jumper)));
+                    var dropButton = g.Buttons.First(e => e.PacketValue.Equals(dropoffset + (i*jumper)));
+                    var scrollButton = g.Buttons.First(e => e.PacketValue.Equals(scrolloffset + (i*jumper)));
+                    var defaultButton = g.Buttons.First(e => e.PacketValue.Equals(defaultoffset + (i*jumper)));
+
+                    var a = g.Labels[i + (i*1)].Text;
+                    var b = g.Labels[i + (i*1) + 1].Text;
+                    var full = a + " " + b;
+                    var name = g.Labels[namepos + i].Text;
+                    var color = g.Labels[namepos + i].Color;
+
+                    Entries.Add(new RunebookEntry(this, recallButton, gateButton, sacredButton, scrollButton,
+                        defaultButton, dropButton, full, name, color));
+                }
+            }
+
+            return true;
+
+        }
+        public bool Rename()
+        {
+            return Open() && RenameButton != null && RenameButton.Click();
+        }
+        public bool Recall()
+        {
+            return StealthAPI.Stealth.Client.CastSpellToObj("Recall", Serial.Value);
+        }
+        public bool Sacred()
+        {
+            return StealthAPI.Stealth.Client.CastSpellToObj("Sacred Journey", Serial.Value);
+        }
+        public bool Gate()
+        {
+            return StealthAPI.Stealth.Client.CastSpellToObj("Gate Travel", Serial.Value);
+        }
+        public bool Close()
+        {
+            Gump g = Gump.GetGump(GumpType);
+            if (g != null)
+                if (!g.Serial.Equals(0))
+                    g.Close();
+            StealthAPI.Stealth.Client.Wait(1000);
+            if (!Gump.WaitForGumpClose(GumpType, GumpDelay))
+                return false;
+            return true;
+        }
+        public bool Open()
+        {
+            if (!Close())
+                return false;
+
+            if (!DoubleClick() || !Gump.WaitForGump(GumpType, GumpDelay))
+                return false;
+            return true;
+        }
+    }
+
+
+    //internal class Program
+    //{
+    //    [STAThread]
+    //    private static void Main()
+    //    {
+    //        RuneBookConfig config = new RuneBookConfig()
+    //        {
+    //            ScrollOffset = 2,
+    //            DropOffset = 3,
+    //            DefaultOffset = 4,
+    //            RecallOffset = 5,
+    //            GateOffset = 6,
+    //            SacredOffset = 7,
+    //            Jumper = 6
+    //        };
+
+    //        Runebook rb = new Runebook(0x4027F04A, config);
+    //        rb.Parse();
+
+    //        rb.Entries[0].Recall();
+
+    //        Console.WriteLine(@"Press any key....");
+    //        Console.ReadKey();
+    //    }
+    //}
+}
+

--- a/ScriptSDK/Samples/UseRunebook.cs
+++ b/ScriptSDK/Samples/UseRunebook.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using ScriptSDK.Gumps;
+using ScriptSDK.Items;
+using ScriptSDK.Mobiles;
+
+namespace ScriptSDK.Samples
+{
+    class UseRunebook
+    {
+        /// <summary> Recall using Runebook.cs Class </summary>
+        /// <param name="bookspot"></param>
+        /// <param name="recalltype"></param>
+        /// <param name="runebookserial"></param>
+        /// <returns>True if no longer in same location</returns>
+        public static bool Travel(Item runebookserial, int bookspot, string recalltype)
+        {
+            var OSIconfig = new RuneBookConfig()
+            {
+                ScrollOffset = 10,
+                DropOffset = 200,
+                DefaultOffset = 300,
+                RecallOffset = 50,
+                GateOffset = 100,
+                SacredOffset = 75,
+                Jumper = 1
+            };
+            Runebook MyRunebook = new Runebook(runebookserial.Serial, OSIconfig);
+            MyRunebook.Recall();
+            runebookserial.DoubleClick();
+            var loc1 = PlayerMobile.GetPlayer().Location;// LOC before recall
+            runebookserial.DoubleClick(); // Open Runebook
+            StealthAPI.Stealth.Client.Wait(1000);
+            Gump g;
+            g = Gump.GetGump((uint)OSIGumpIDs.Runebook); //OSI
+            if (g == null)
+            {
+                StealthAPI.Stealth.Client.AddToSystemJournal("Gump is Null");
+                return false;
+            }
+            else
+            {
+                foreach (var e in g.Buttons)
+                {
+                    if (!e.PacketValue.Equals(OSIconfig.RecallOffset + bookspot - 1) && !e.Graphic.Released.Equals(2103) &&
+                        !e.Graphic.Pressed.Equals(2104)) continue;
+                    if (recalltype == "Recall")
+                    {
+                        GumpButton recallButton = g.Buttons.First(i => i.PacketValue.Equals(OSIconfig.RecallOffset + (bookspot - 1)));
+                        recallButton.Click();
+                        break;
+                    }
+                }
+            }
+            StealthAPI.Stealth.Client.Wait(false ? 2000 : 3500);
+            var loc2 = PlayerMobile.GetPlayer().Location; // LOC after recall
+            return loc1 != loc2; // Compare Locs to see if you moved.
+        }
+    }
+}

--- a/ScriptSDK/ScriptSDK.csproj
+++ b/ScriptSDK/ScriptSDK.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Gumps\GumpEnums.cs" />
+    <Compile Include="Items\Runebook.cs" />
+    <Compile Include="Samples\UseRunebook.cs" />
     <Compile Include="Stealth API\Converters.cs" />
     <Compile Include="Stealth API\Data\AboutData.cs" />
     <Compile Include="Stealth API\Data\BuffIcon.cs" />

--- a/ScriptSDK/ScriptSDK.csproj
+++ b/ScriptSDK/ScriptSDK.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Stealth API\Network\DataType.cs" />
     <Compile Include="Stealth API\Network\ExecEventProcData.cs" />
     <Compile Include="Stealth API\Network\Packet.cs" />
+    <Compile Include="Stealth API\Network\PacketOLD.cs" />
     <Compile Include="Stealth API\Network\PacketType.cs" />
     <Compile Include="Stealth API\Network\ServerEventArgs.cs" />
     <Compile Include="Stealth API\Network\StealthClient.cs" />

--- a/ScriptSDK/Stealth API/Network/Packet.cs
+++ b/ScriptSDK/Stealth API/Network/Packet.cs
@@ -2,126 +2,127 @@
 using System.IO;
 using System.Linq;
 using System.Text;
-#pragma warning disable 1591
 
 namespace StealthAPI
 {
-    internal class Packet
+    public class Packet
     {
-        internal byte[] Data;
-        internal int DataLength;
-        internal PacketType Method;
-
         public Packet()
         {
             Data = new byte[0];
+            UnusedData = new byte[0];
         }
 
+        public int DataLength => Data.Length;
+
+        internal PacketType Method { get; set; }
+
+        public byte[] Data;
+        public byte[] UnusedData;
+        
         public override string ToString()
         {
             return string.Join(" ", Data.Select(b => b.ToString("X2")));
         }
 
-        internal void AddParameter(object p)
+        public void AddParameters(params object[] p)
         {
-            using (var ms = new MemoryStream())
-            using (var bw = new BinaryWriter(ms))
+            using (MemoryStream _ms = new MemoryStream())
+            using (BinaryWriter _bw = new BinaryWriter(_ms))
             {
-                switch (Type.GetTypeCode(p.GetType()))
+                foreach (var item in p)
                 {
-                    case TypeCode.Boolean:
-                        bw.Write((bool) p);
-                        break;
-                    case TypeCode.Byte:
-                        bw.Write((byte) p);
-                        break;
-                    case TypeCode.Char:
-                        bw.Write((char) p);
-                        break;
-                    case TypeCode.Decimal:
-                        bw.Write((decimal) p);
-                        break;
-                    case TypeCode.Double:
-                        bw.Write((double) p);
-                        break;
-                    case TypeCode.Single:
-                        bw.Write((float) p);
-                        break;
-                    case TypeCode.Int16:
-                        bw.Write((short) p);
-                        break;
-                    case TypeCode.String:
-                        var bytes = Encoding.Unicode.GetBytes((string) p);
-                        bw.Write(((string) p).Length);
-                        bw.Write(bytes, 0, bytes.Length);
-                        break;
-                    case TypeCode.Int32:
-                        bw.Write((int) p);
-                        break;
-                    case TypeCode.Int64:
-                        bw.Write((long) p);
-                        break;
-                    case TypeCode.SByte:
-                        bw.Write((sbyte) p);
-                        break;
-                    case TypeCode.UInt16:
-                        bw.Write((ushort) p);
-                        break;
-                    case TypeCode.UInt32:
-                        bw.Write((uint) p);
-                        break;
-                    case TypeCode.UInt64:
-                        bw.Write((ulong) p);
-                        break;
-                    case TypeCode.DateTime:
-                        bw.Write(((DateTime) p).ToDouble());
-                        break;
-                    default:
-                        if (p.GetType() == typeof (byte[]))
-                        {
-                            bw.Write((byte[]) p);
-                        }
-                        else if (p.GetType() == typeof (char[]))
-                        {
-                            bw.Write((char[]) p);
-                        }
-                        else if (p.GetType() == typeof (ushort[]))
-                        {
-                            var bytearray = ((ushort[]) p).SelectMany(i => BitConverter.GetBytes(i)).ToArray();
-                            bw.Write(bytearray);
-                        }
-                        else if (p.GetType() == typeof (uint[]))
-                        {
-                            var bytearray = ((uint[]) p).SelectMany(i => BitConverter.GetBytes(i)).ToArray();
-                            bw.Write(bytearray);
-                        }
-                        else
-                        {
-                            throw new ArgumentException("List type not supported");
-                        }
-
-                        break;
+                    AddParameter(_bw, item);
                 }
-                ms.Seek(0, SeekOrigin.Begin);
-                var tmp = ms.ToArray();
-                var pos = Data.Length;
-                Array.Resize(ref Data, Data.Length + tmp.Length);
-                Array.Copy(tmp, 0, Data, pos, tmp.Length);
+                Data = _ms.ToArray();
             }
         }
 
-        internal byte[] GetBytes()
+        private void AddParameter(BinaryWriter _bw, object p)
         {
-            byte[] buffer;
-            using (var tmp = new MemoryStream())
-            using (var bw = new BinaryWriter(tmp))
+            switch (Type.GetTypeCode(p.GetType()))
             {
-                bw.Write((ushort) Method);
-                bw.Write(DataLength);
-                bw.Write(Data);
-                bw.Flush();
-                buffer = tmp.ToArray();
+                case TypeCode.Boolean:
+                    _bw.Write((bool)p);
+                    break;
+                case TypeCode.Byte:
+                    _bw.Write((byte)p);
+                    break;
+                case TypeCode.Char:
+                    _bw.Write((char)p);
+                    break;
+                case TypeCode.Decimal:
+                    _bw.Write((decimal)p);
+                    break;
+                case TypeCode.Double:
+                    _bw.Write((double)p);
+                    break;
+                case TypeCode.Single:
+                    _bw.Write((float)p);
+                    break;
+                case TypeCode.Int16:
+                    _bw.Write((short)p);
+                    break;
+                case TypeCode.String:
+                    byte[] bytes = Encoding.Unicode.GetBytes((string)p);
+                    _bw.Write(((string)p).Length);
+                    _bw.Write(bytes, 0, bytes.Length);
+                    break;
+                case TypeCode.Int32:
+                    _bw.Write((int)p);
+                    break;
+                case TypeCode.Int64:
+                    _bw.Write((long)p);
+                    break;
+                case TypeCode.SByte:
+                    _bw.Write((sbyte)p);
+                    break;
+                case TypeCode.UInt16:
+                    _bw.Write((ushort)p);
+                    break;
+                case TypeCode.UInt32:
+                    _bw.Write((uint)p);
+                    break;
+                case TypeCode.UInt64:
+                    _bw.Write((ulong)p);
+                    break;
+                case TypeCode.DateTime:
+                    _bw.Write(((DateTime)p).ToDouble());
+                    break;
+                default:
+                    if (p.GetType() == typeof(byte[]))
+                    {
+                        _bw.Write((byte[])p);
+                    }
+                    else if (p.GetType() == typeof(char[]))
+                    {
+                        _bw.Write((char[])p);
+                    }
+                    else if (p.GetType() == typeof(ushort[]))
+                    {
+                        byte[] bytearray = ((ushort[])p).SelectMany(i => BitConverter.GetBytes(i)).ToArray();
+                        _bw.Write(bytearray);
+                    }
+                    else if (p.GetType() == typeof(uint[]))
+                    {
+                        byte[] bytearray = ((uint[])p).SelectMany(i => BitConverter.GetBytes(i)).ToArray();
+                        _bw.Write(bytearray);
+                    }
+                    else
+                    {
+                        throw new ArgumentException("List type not supported");
+                    }
+
+                    break;
             }
+        }
+
+        public byte[] GetBytes()
+        {
+            byte[] buffer = new byte[DataLength + 6];
+            Array.Copy(BitConverter.GetBytes((ushort)Method), 0, buffer, 0, 2);
+            Array.Copy(BitConverter.GetBytes(DataLength), 0, buffer, 2, 4);
+            Array.Copy(Data, 0, buffer, 6, DataLength);
             return buffer;
         }
     }

--- a/ScriptSDK/Stealth API/Network/Packet.cs
+++ b/ScriptSDK/Stealth API/Network/Packet.cs
@@ -2,10 +2,12 @@
 using System.IO;
 using System.Linq;
 using System.Text;
-
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace StealthAPI
 {
+
     public class Packet
+
     {
         public Packet()
         {

--- a/ScriptSDK/Stealth API/Network/PacketOLD.cs
+++ b/ScriptSDK/Stealth API/Network/PacketOLD.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+#pragma warning disable 1591
+
+//namespace StealthAPI
+//{
+//    internal class Packet
+//    {
+//        internal byte[] Data;
+//        internal int DataLength;
+//        internal PacketType Method;
+
+//        public Packet()
+//        {
+//            Data = new byte[0];
+//        }
+
+//        public override string ToString()
+//        {
+//            return string.Join(" ", Data.Select(b => b.ToString("X2")));
+//        }
+
+//        internal void AddParameter(object p)
+//        {
+//            using (var ms = new MemoryStream())
+//            using (var bw = new BinaryWriter(ms))
+//            {
+//                switch (Type.GetTypeCode(p.GetType()))
+//                {
+//                    case TypeCode.Boolean:
+//                        bw.Write((bool) p);
+//                        break;
+//                    case TypeCode.Byte:
+//                        bw.Write((byte) p);
+//                        break;
+//                    case TypeCode.Char:
+//                        bw.Write((char) p);
+//                        break;
+//                    case TypeCode.Decimal:
+//                        bw.Write((decimal) p);
+//                        break;
+//                    case TypeCode.Double:
+//                        bw.Write((double) p);
+//                        break;
+//                    case TypeCode.Single:
+//                        bw.Write((float) p);
+//                        break;
+//                    case TypeCode.Int16:
+//                        bw.Write((short) p);
+//                        break;
+//                    case TypeCode.String:
+//                        var bytes = Encoding.Unicode.GetBytes((string) p);
+//                        bw.Write(((string) p).Length);
+//                        bw.Write(bytes, 0, bytes.Length);
+//                        break;
+//                    case TypeCode.Int32:
+//                        bw.Write((int) p);
+//                        break;
+//                    case TypeCode.Int64:
+//                        bw.Write((long) p);
+//                        break;
+//                    case TypeCode.SByte:
+//                        bw.Write((sbyte) p);
+//                        break;
+//                    case TypeCode.UInt16:
+//                        bw.Write((ushort) p);
+//                        break;
+//                    case TypeCode.UInt32:
+//                        bw.Write((uint) p);
+//                        break;
+//                    case TypeCode.UInt64:
+//                        bw.Write((ulong) p);
+//                        break;
+//                    case TypeCode.DateTime:
+//                        bw.Write(((DateTime) p).ToDouble());
+//                        break;
+//                    default:
+//                        if (p.GetType() == typeof (byte[]))
+//                        {
+//                            bw.Write((byte[]) p);
+//                        }
+//                        else if (p.GetType() == typeof (char[]))
+//                        {
+//                            bw.Write((char[]) p);
+//                        }
+//                        else if (p.GetType() == typeof (ushort[]))
+//                        {
+//                            var bytearray = ((ushort[]) p).SelectMany(i => BitConverter.GetBytes(i)).ToArray();
+//                            bw.Write(bytearray);
+//                        }
+//                        else if (p.GetType() == typeof (uint[]))
+//                        {
+//                            var bytearray = ((uint[]) p).SelectMany(i => BitConverter.GetBytes(i)).ToArray();
+//                            bw.Write(bytearray);
+//                        }
+//                        else
+//                        {
+//                            throw new ArgumentException("List type not supported");
+//                        }
+
+//                        break;
+//                }
+//                ms.Seek(0, SeekOrigin.Begin);
+//                var tmp = ms.ToArray();
+//                var pos = Data.Length;
+//                Array.Resize(ref Data, Data.Length + tmp.Length);
+//                Array.Copy(tmp, 0, Data, pos, tmp.Length);
+//            }
+//        }
+
+//        internal byte[] GetBytes()
+//        {
+//            byte[] buffer;
+//            using (var tmp = new MemoryStream())
+//            using (var bw = new BinaryWriter(tmp))
+//            {
+//                bw.Write((ushort) Method);
+//                bw.Write(DataLength);
+//                bw.Write(Data);
+//                bw.Flush();
+//                buffer = tmp.ToArray();
+//            }
+//            return buffer;
+//        }
+//    }
+//}

--- a/ScriptSDK/Stealth API/Stealth.cs
+++ b/ScriptSDK/Stealth API/Stealth.cs
@@ -876,7 +876,6 @@ namespace StealthAPI
         private StealthClient _client;
         //private readonly Dictionary<string, int> _skills = new Dictionary<string, int>();
         private uint _dropDelay;
-        private byte _eventFunctionCounter;
         private bool _isStopped;
 
         private static Stealth _instance;

--- a/ScriptSDK/Stealth API/Stealth.cs
+++ b/ScriptSDK/Stealth API/Stealth.cs
@@ -92,7 +92,7 @@ namespace StealthAPI
             {
                 var handler = ItemInfoInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ItemInfo, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ItemInfo);
                 ItemInfoInternal += value;
             }
             remove
@@ -102,7 +102,7 @@ namespace StealthAPI
                 var handler = ItemInfoInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ItemInfo);
                 }
             }
@@ -113,7 +113,7 @@ namespace StealthAPI
             {
                 var handler = ItemDeletedInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ItemDeleted, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ItemDeleted);
                 ItemDeletedInternal += value;
             }
             remove
@@ -123,7 +123,7 @@ namespace StealthAPI
                 var handler = ItemDeletedInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ItemDeleted);
                 }
             }
@@ -134,7 +134,7 @@ namespace StealthAPI
             {
                 var handler = SpeechInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Speech, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Speech);
                 SpeechInternal += value;
             }
             remove
@@ -144,7 +144,7 @@ namespace StealthAPI
                 var handler = SpeechInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Speech);
                 }
             }
@@ -155,7 +155,7 @@ namespace StealthAPI
             {
                 var handler = DrawGamePlayerInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.DrawGamePlayer, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.DrawGamePlayer);
                 DrawGamePlayerInternal += value;
             }
             remove
@@ -165,7 +165,6 @@ namespace StealthAPI
                 var handler = DrawGamePlayerInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.DrawGamePlayer);
                 }
             }
@@ -176,7 +175,7 @@ namespace StealthAPI
             {
                 var handler = MoveRejectionInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.MoveRejection, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.MoveRejection);
                 MoveRejectionInternal += value;
             }
             remove
@@ -186,7 +185,7 @@ namespace StealthAPI
                 var handler = MoveRejectionInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.MoveRejection);
                 }
             }
@@ -197,7 +196,7 @@ namespace StealthAPI
             {
                 var handler = DrawContainerInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.DrawContainer, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.DrawContainer);
                 DrawContainerInternal += value;
             }
             remove
@@ -207,7 +206,7 @@ namespace StealthAPI
                 var handler = DrawContainerInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.DrawContainer);
                 }
             }
@@ -218,7 +217,7 @@ namespace StealthAPI
             {
                 var handler = AddItemToContainerInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.AddItemToContainer, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.AddItemToContainer);
                 AddItemToContainerInternal += value;
             }
             remove
@@ -228,7 +227,7 @@ namespace StealthAPI
                 var handler = AddItemToContainerInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.AddItemToContainer);
                 }
             }
@@ -239,7 +238,7 @@ namespace StealthAPI
             {
                 var handler = AddMultipleItemsInContainerInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.AddMultipleItemsInCont, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.AddMultipleItemsInCont);
                 AddMultipleItemsInContainerInternal += value;
             }
             remove
@@ -249,7 +248,7 @@ namespace StealthAPI
                 var handler = AddMultipleItemsInContainerInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.AddMultipleItemsInCont);
                 }
             }
@@ -260,7 +259,7 @@ namespace StealthAPI
             {
                 var handler = RejectMoveItemInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.RejectMoveItem, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.RejectMoveItem);
                 RejectMoveItemInternal += value;
             }
             remove
@@ -270,7 +269,7 @@ namespace StealthAPI
                 var handler = RejectMoveItemInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.RejectMoveItem);
                 }
             }
@@ -281,7 +280,7 @@ namespace StealthAPI
             {
                 var handler = UpdateCharInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.UpdateChar, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.UpdateChar);
                 UpdateCharInternal += value;
             }
             remove
@@ -291,7 +290,7 @@ namespace StealthAPI
                 var handler = UpdateCharInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.UpdateChar);
                 }
             }
@@ -302,7 +301,7 @@ namespace StealthAPI
             {
                 var handler = DrawObjectInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.DrawObject, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.DrawObject);
                 DrawObjectInternal += value;
             }
             remove
@@ -312,7 +311,7 @@ namespace StealthAPI
                 var handler = DrawObjectInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.DrawObject);
                 }
             }
@@ -323,7 +322,7 @@ namespace StealthAPI
             {
                 var handler = MenuInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Menu, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Menu);
                 MenuInternal += value;
             }
             remove
@@ -333,7 +332,7 @@ namespace StealthAPI
                 var handler = MenuInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Menu);
                 }
             }
@@ -344,7 +343,7 @@ namespace StealthAPI
             {
                 var handler = MapMessageInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.MapMessage, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.MapMessage);
                 MapMessageInternal += value;
             }
             remove
@@ -354,7 +353,7 @@ namespace StealthAPI
                 var handler = MapMessageInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.MapMessage);
                 }
             }
@@ -365,7 +364,7 @@ namespace StealthAPI
             {
                 var handler = AllowRefuseAttackInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Allow_RefuseAttack, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Allow_RefuseAttack);
                 AllowRefuseAttackInternal += value;
             }
             remove
@@ -375,7 +374,7 @@ namespace StealthAPI
                 var handler = AllowRefuseAttackInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Allow_RefuseAttack);
                 }
             }
@@ -386,7 +385,7 @@ namespace StealthAPI
             {
                 var handler = ClilocSpeechInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ClilocSpeech, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ClilocSpeech);
                 ClilocSpeechInternal += value;
             }
             remove
@@ -396,7 +395,7 @@ namespace StealthAPI
                 var handler = ClilocSpeechInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ClilocSpeech);
                 }
             }
@@ -408,7 +407,7 @@ namespace StealthAPI
             {
                 var handler = ClilocSpeechAffixInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ClilocSpeechAffix, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ClilocSpeechAffix);
                 ClilocSpeechAffixInternal += value;
             }
             remove
@@ -418,7 +417,7 @@ namespace StealthAPI
                 var handler = ClilocSpeechAffixInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ClilocSpeechAffix);
                 }
             }
@@ -430,7 +429,7 @@ namespace StealthAPI
             {
                 var handler = UnicodeSpeechInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.UnicodeSpeech, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.UnicodeSpeech);
                 UnicodeSpeechInternal += value;
             }
             remove
@@ -440,7 +439,7 @@ namespace StealthAPI
                 var handler = UnicodeSpeechInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.UnicodeSpeech);
                 }
             }
@@ -451,7 +450,7 @@ namespace StealthAPI
             {
                 var handler = Buff_DebuffSystemInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Buff_DebuffSystem, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Buff_DebuffSystem);
                 Buff_DebuffSystemInternal += value;
             }
             remove
@@ -461,7 +460,7 @@ namespace StealthAPI
                 var handler = Buff_DebuffSystemInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Buff_DebuffSystem);
                 }
             }
@@ -472,7 +471,7 @@ namespace StealthAPI
             {
                 var handler = ClientSendResyncInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ClientSendResync, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ClientSendResync);
                 ClientSendResyncInternal += value;
             }
             remove
@@ -482,7 +481,7 @@ namespace StealthAPI
                 var handler = ClientSendResyncInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ClientSendResync);
                 }
             }
@@ -493,7 +492,7 @@ namespace StealthAPI
             {
                 var handler = CharAnimationInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.CharAnimation, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.CharAnimation);
                 CharAnimationInternal += value;
             }
             remove
@@ -503,7 +502,7 @@ namespace StealthAPI
                 var handler = CharAnimationInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.CharAnimation);
                 }
             }
@@ -514,7 +513,7 @@ namespace StealthAPI
             {
                 var handler = ICQDisconnectInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQDisconnect, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQDisconnect);
                 ICQDisconnectInternal += value;
             }
             remove
@@ -524,7 +523,7 @@ namespace StealthAPI
                 var handler = ICQDisconnectInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ICQDisconnect);
                 }
             }
@@ -535,7 +534,7 @@ namespace StealthAPI
             {
                 var handler = ICQConnectInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQConnect, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQConnect);
                 ICQConnectInternal += value;
             }
             remove
@@ -545,7 +544,7 @@ namespace StealthAPI
                 var handler = ICQConnectInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ICQConnect);
                 }
             }
@@ -556,7 +555,7 @@ namespace StealthAPI
             {
                 var handler = ICQIncomingTextInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQIncomingText, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQIncomingText);
                 ICQIncomingTextInternal += value;
             }
             remove
@@ -566,7 +565,7 @@ namespace StealthAPI
                 var handler = ICQIncomingTextInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ICQIncomingText);
                 }
             }
@@ -577,7 +576,7 @@ namespace StealthAPI
             {
                 var handler = ICQErrorInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQError, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.ICQError);
                 ICQErrorInternal += value;
             }
             remove
@@ -587,7 +586,7 @@ namespace StealthAPI
                 var handler = ICQErrorInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.ICQError);
                 }
             }
@@ -598,7 +597,7 @@ namespace StealthAPI
             {
                 var handler = IncomingGumpInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.IncomingGump, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.IncomingGump);
                 IncomingGumpInternal += value;
             }
             remove
@@ -608,7 +607,7 @@ namespace StealthAPI
                 var handler = IncomingGumpInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.IncomingGump);
                 }
             }
@@ -619,7 +618,7 @@ namespace StealthAPI
             {
                 var handler = Timer1Internal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Timer1, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Timer1);
                 Timer1Internal += value;
             }
             remove
@@ -629,7 +628,7 @@ namespace StealthAPI
                 var handler = Timer1Internal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Timer1);
                 }
             }
@@ -640,7 +639,7 @@ namespace StealthAPI
             {
                 var handler = Timer2Internal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Timer2, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Timer2);
                 Timer2Internal += value;
             }
             remove
@@ -650,7 +649,7 @@ namespace StealthAPI
                 var handler = Timer2Internal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Timer2);
                 }
             }
@@ -661,7 +660,7 @@ namespace StealthAPI
             {
                 var handler = WindowsMessageInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.WindowsMessage, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.WindowsMessage);
                 WindowsMessageInternal += value;
             }
             remove
@@ -671,7 +670,7 @@ namespace StealthAPI
                 var handler = WindowsMessageInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.WindowsMessage);
                 }
             }
@@ -682,7 +681,7 @@ namespace StealthAPI
             {
                 var handler = SoundInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Sound, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Sound);
                 SoundInternal += value;
             }
             remove
@@ -692,7 +691,7 @@ namespace StealthAPI
                 var handler = SoundInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Sound);
                 }
             }
@@ -703,7 +702,7 @@ namespace StealthAPI
             {
                 var handler = DeathInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Death, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.Death);
                 DeathInternal += value;
             }
             remove
@@ -713,7 +712,7 @@ namespace StealthAPI
                 var handler = DeathInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.Death);
                 }
             }
@@ -724,7 +723,7 @@ namespace StealthAPI
             {
                 var handler = QuestArrowInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.QuestArrow, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.QuestArrow);
                 QuestArrowInternal += value;
             }
             remove
@@ -734,7 +733,7 @@ namespace StealthAPI
                 var handler = QuestArrowInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.QuestArrow);
                 }
             }
@@ -745,7 +744,7 @@ namespace StealthAPI
             {
                 var handler = PartyInviteInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.PartyInvite, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.PartyInvite);
                 PartyInviteInternal += value;
             }
             remove
@@ -755,7 +754,7 @@ namespace StealthAPI
                 var handler = PartyInviteInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.PartyInvite);
                 }
             }
@@ -767,7 +766,7 @@ namespace StealthAPI
             {
                 var handler = MapPinInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.MapPin, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.MapPin);
                 MapPinInternal += value;
             }
             remove
@@ -777,7 +776,7 @@ namespace StealthAPI
                 var handler = MapPinInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.MapPin);
                 }
             }
@@ -789,7 +788,7 @@ namespace StealthAPI
             {
                 var handler = GumpTextEntryInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.GumpTextEntry, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.GumpTextEntry);
                 GumpTextEntryInternal += value;
             }
             remove
@@ -799,7 +798,7 @@ namespace StealthAPI
                 var handler = GumpTextEntryInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.GumpTextEntry);
                 }
             }
@@ -811,7 +810,7 @@ namespace StealthAPI
             {
                 var handler = GraphicalEffectInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.GraphicalEffect, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.GraphicalEffect);
                 GraphicalEffectInternal += value;
             }
             remove
@@ -821,7 +820,7 @@ namespace StealthAPI
                 var handler = GraphicalEffectInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.GraphicalEffect);
                 }
             }
@@ -833,7 +832,7 @@ namespace StealthAPI
             {
                 var handler = IRCIncomingTextInternal;
                 if (handler == null)
-                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.IRCIncomingText, _eventFunctionCounter++);
+                    _client.SendPacket(PacketType.SCSetEventProc, EventTypes.IRCIncomingText);
                 IRCIncomingTextInternal += value;
             }
             remove
@@ -843,7 +842,7 @@ namespace StealthAPI
                 var handler = IRCIncomingTextInternal;
                 if (handler == null)
                 {
-                    _eventFunctionCounter--;
+                    
                     _client.SendPacket(PacketType.SCClearEventProc, EventTypes.IRCIncomingText);
                 }
             }
@@ -855,7 +854,7 @@ namespace StealthAPI
         //    {
         //        var handler = SkypeIncomingTextInternal;
         //        if (handler == null)
-        //            _client.SendPacket(PacketType.SCSetEventProc, EventTypes.SkypeEvent, _eventFunctionCounter++);
+        //            _client.SendPacket(PacketType.SCSetEventProc, EventTypes.SkypeEvent);
         //        SkypeIncomingTextInternal += value;
         //    }
         //    remove
@@ -865,7 +864,7 @@ namespace StealthAPI
         //        var handler = SkypeIncomingTextInternal;
         //        if (handler == null)
         //        {
-        //            _eventFunctionCounter--;
+        //            
         //            _client.SendPacket(PacketType.SCClearEventProc, EventTypes.SkypeEvent);
         //        }
         //    }


### PR DESCRIPTION
There was an issue where a Packet Parse Error would occur in Stealth when using the ScriptSDK.  Updated the packet.cs to be that of ScriptDotNet's and then changed some of the SystemEvents to match the packet parsing.